### PR TITLE
ci: upgrade actions/checkout from `v3` to `v4`

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -34,7 +34,7 @@ jobs:
       HUGO_VERSION: 0.117.0
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
       - name: Setup Go


### PR DESCRIPTION
https://github.com/actions/checkout#checkout-v4