### PR TITLE
Bump Hugo version, improve developer experience

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "features": {
     "ghcr.io/devcontainers/features/hugo:1": {
       "extended": true,
-      "version": "0.119.0"
+      "version": "0.121.1"
     },
     "ghcr.io/devcontainers/features/node:1": {}
   },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/go:1",
+  "features": {
+    "ghcr.io/devcontainers/features/hugo:1": {
+      "extended": true,
+      "version": "0.119.0"
+    },
+    "ghcr.io/devcontainers/features/node:1": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "mhutchie.git-graph",
+        "esbenp.prettier-vscode",
+        "tamasfe.even-better-toml",
+        "budparr.language-hugo-vscode"
+      ]
+    }
+  },
+  "forwardPorts": [1313]
+}

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -31,7 +31,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.117.0
+      HUGO_VERSION: 0.121.1
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.117.0'
+          hugo-version: ${{ env.HUGO_VERSION }}
           extended: true
       - name: Build with Hugo
         env:

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,12 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"mhutchie.git-graph",
+        "esbenp.prettier-vscode",
+        "tamasfe.even-better-toml",
+        "budparr.language-hugo-vscode"
+	]
+}

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,4 +3,4 @@ publish = "public"
 command = "hugo --gc --minify -b ${DEPLOY_PRIME_URL}"
 
 [build.environment]
-HUGO_VERSION = "0.117.0"
+HUGO_VERSION = "0.121.1"


### PR DESCRIPTION
## What does this PR do?

### 1. Bump Hugo version

Use Hugo `v0.121.1` for Netlify & GitHub pages deployment

### 2. Improve developer experience

Add `.devcontainer/devcontainer.json` & `.vscode/extensions.json` releavant for a Hugo project.

### 3. Remove redundant Hugo version specification

Use `${{ env.HUGO_VERSION }}`  to specify Hugo version in  GitHub action workflow.