### PR TITLE
ci: use `configure-pages` action to get output base url

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -43,7 +43,7 @@ jobs:
           go-version: '1.21'
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v4
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -41,6 +41,9 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.21'
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v2
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
@@ -54,7 +57,7 @@ jobs:
         run: |
           hugo \
             --gc --minify \
-            --baseURL "https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/"
+            --baseURL "${{ steps.pages.outputs.base_url }}/"
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
         with:


### PR DESCRIPTION
Use [actions/configure-pages](https://github.com/actions/configure-pages) to get the base url for GitHub pages deployment, instead of constructing it with `https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/`, which fails when trying to deploy to a user/org site.

This is because the base URL for those sites is just `https://${{ github.repository_owner }}.github.io/`. Ultimately this mismatch causes integrity errors on the deployed site because GH Pages doesn't serve the correct files for reasons I don't quite understand, but this is the root cause.

`configure-pages` is designed to solve this problem by making available the base url as an output. It can also be configured to do some other things, but here it just extracts metadata.

This is adapted from how [hugo's GitHub hosting guide](https://gohugo.io/hosting-and-deployment/hosting-on-github/) handles it.

This should allow a Hextra site created from this repository to be reliably deployed to either a user/org site or a project site, without additional configuration.

I have very little experience with GH Actions, so it's very possible this is an inefficient/bad way to handle it, but hopefully it at least makes the cause of the problem clear for others who might encounter it.