### PR TITLE
Bump Hugo to 0.147.7 in devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "features": {
     "ghcr.io/devcontainers/features/hugo:1": {
       "extended": true,
-      "version": "0.145.0"
+      "version": "0.147.7"
     },
     "ghcr.io/devcontainers/features/node:1": {}
   },


### PR DESCRIPTION
A natural follow up after https://github.com/imfing/hextra/commit/3a13d44d3ca49014a17aa2e1f0c10984eeb4a052 .